### PR TITLE
fix(test): resolve flaky PersonalAccessTokens "should show personal a…

### DIFF
--- a/assets/js/common/PersonalAccessTokens/PersonalAccessTokens.test.jsx
+++ b/assets/js/common/PersonalAccessTokens/PersonalAccessTokens.test.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
-import { formatISO } from 'date-fns';
+import { addDays, formatISO } from 'date-fns';
 import { faker } from '@faker-js/faker';
 import { personalAccessTokenFactory } from '@lib/test-utils/factories';
 import { DEFAULT_TIMEZONE, formatDateOnly } from '@lib/timezones';
@@ -13,7 +13,18 @@ import PersonalAccessTokens from './PersonalAccessTokens';
 
 describe('PersonalAccessTokens', () => {
   it('should show personal access tokens', () => {
-    const tokens = personalAccessTokenFactory.buildList(3);
+    // Override `name` and `expires_at` to guarantee uniqueness across the
+    // generated tokens. Faker may otherwise produce duplicate display names or
+    // two future dates that format to the same calendar day, which causes
+    // `getByText` to find multiple matches and fail intermittently.
+    const baseDate = new Date('2099-01-01T00:00:00Z');
+    const tokens = personalAccessTokenFactory
+      .buildList(3)
+      .map((token, index) => ({
+        ...token,
+        name: `pat-${index}-${token.name}`,
+        expires_at: formatISO(addDays(baseDate, index)),
+      }));
     render(
       <PersonalAccessTokens
         personalAccessTokens={tokens}


### PR DESCRIPTION
…ccess tokens"

Root cause: The test built 3 tokens via personalAccessTokenFactory.buildList(3), which uses faker.internet.displayName() for `name` and formatISO(faker.date.future()) for `expires_at`. Both fields can collide across the three generated tokens: display names occasionally repeat, and two future timestamps frequently fall on the same calendar day. When the rendered list contained duplicate names or duplicate formatted "Expires: <date>" strings, screen.getByText(...) found multiple matching elements and threw, intermittently failing the test (~1/50 locally).

Fix: In the test, override the factory output so each of the 3 tokens has a unique `name` (prefixed with its index) and a deterministic, distinct `expires_at` (2099-01-01 + index days). Production code is untouched; the factory is unchanged so other tests/stories that depend on it are unaffected.

Flaky tests report payload:
[
  {
    "name": "PersonalAccessTokens::should show personal access tokens",
    "max_score": 0.07001,
    "occurrences": 12,
    "first_seen": "2026-04-01T04:50:23Z",
    "last_seen": "2026-05-12T04:44:48Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-01T04:50:23Z",
        "commit": "ccc91639f04ea26ed14e5c7eeb59807d9f1f1d3b",
        "run_id": "23832077383",
        "score": 0.06551
      },
      {
        "timestamp": "2026-04-03T04:30:19Z",
        "commit": "b8ad8ce4166e05da624b4be4751564144bbe6d34",
        "run_id": "23933447473",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-08T04:36:50Z",
        "commit": "c1c8179aea75eb25e7a1b991435fe595884aa945",
        "run_id": "24117491595",
        "score": 0.06823
      },
      {
        "timestamp": "2026-04-12T04:49:17Z",
        "commit": "8b846349ed7ab730785cb8395f839a927bde9b76",
        "run_id": "24298708972",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-16T04:17:40Z",
        "commit": "116041531559de669d60a9c31a82770a55a6973a",
        "run_id": "24491207415",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-24T04:16:50Z",
        "commit": "4d018d598251ab302f8515535a0582af06fcc0e4",
        "run_id": "24871468908",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-25T03:59:43Z",
        "commit": "f003f86717bdf66015b8712a9443c63b345089d1",
        "run_id": "24921768160",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-26T04:23:19Z",
        "commit": "f003f86717bdf66015b8712a9443c63b345089d1",
        "run_id": "24947852183",
        "score": 0.05001
      },
      {
        "timestamp": "2026-05-03T04:46:41Z",
        "commit": "aed802d8ce1e30739e2fdb764731615bef86b31c",
        "run_id": "25269875694",
        "score": 0.04751
      },
      {
        "timestamp": "2026-05-05T04:18:53Z",
        "commit": "647fea1a7ce07030327a11a64c7e83eebafbd620",
        "run_id": "25357040669",
        "score": 0.02501
      },
      {
        "timestamp": "2026-05-11T05:05:10Z",
        "commit": "ed080da4b45c0a477a9cb84d82aa87a7a9cf7a97",
        "run_id": "25650804239",
        "score": 0.07001
      },
      {
        "timestamp": "2026-05-12T04:44:48Z",
        "commit": "2cdec8baa70752e99bb973e0aef129a1ff26f4e8",
        "run_id": "25713277735",
        "score": 0.02501
      }
    ],
    "status": "pending",
    "test_file": "assets/js/common/PersonalAccessTokens/PersonalAccessTokens.test.jsx",
    "slug": "personal-access-tokens",
    "branch": "fix-flaky/personal-access-tokens"
  }
]

# Description

Please include a summary of the changes and the related issue, if it exists. 
Also, include relevant motivation and context for this PR. List any dependencies that are required for this change.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [ ] **DONE**
