### PR TITLE
fix(test): resolve flaky UserForm "should save the user"

### DIFF
--- a/assets/js/pages/Users/UserForm.test.jsx
+++ b/assets/js/pages/Users/UserForm.test.jsx
@@ -195,16 +195,25 @@ describe('UserForm', () => {
       />
     );
 
-    await user.type(screen.getByPlaceholderText('Enter full name'), fullname);
-    await user.type(screen.getByPlaceholderText('Enter email address'), email);
-    await user.type(screen.getByPlaceholderText('Enter username'), username);
-    await user.type(screen.getByPlaceholderText('Enter password'), password);
-    await user.type(screen.getByPlaceholderText('Re-enter password'), password);
+    // Use paste() instead of type() for the text fields. Random fixtures
+    // (especially long timezones like "America/Argentina/ComodRivadavia")
+    // can push the cumulative per-keystroke typing time past the default 5s
+    // jest timeout, causing the test to fail intermittently.
+    await user.click(screen.getByPlaceholderText('Enter full name'));
+    await user.paste(fullname);
+    await user.click(screen.getByPlaceholderText('Enter email address'));
+    await user.paste(email);
+    await user.click(screen.getByPlaceholderText('Enter username'));
+    await user.paste(username);
+    await user.click(screen.getByPlaceholderText('Enter password'));
+    await user.paste(password);
+    await user.click(screen.getByPlaceholderText('Re-enter password'));
+    await user.paste(password);
     const timezoneSelectorInput = screen.getByRole('combobox', {
       name: 'Timezone',
     });
     await user.click(timezoneSelectorInput);
-    await user.type(timezoneSelectorInput, timezone);
+    await user.paste(timezone);
     await user.click(await screen.findByText(getTimezoneLabel(timezone)));
 
     await user.click(screen.getByRole('button', { name: 'Save' }));


### PR DESCRIPTION
Root cause: The test simulates per-character typing into 6 form fields (fullname, email, username, password x2, timezone search) using `userEvent.type`. With long random fixtures from faker - in particular timezones like "America/Argentina/ComodRivadavia" (32 chars) and long emails/passwords - the cumulative typing time can exceed jest's default 5000ms per-test timeout, causing the test to fail intermittently.

Locally reproduced 11/50 failures, all due to the test exceeding 5000ms.

Fix: Replace `user.type` with `user.click` + `user.paste` for the text fields and the timezone search. This still goes through React's input change handlers (so the form state is updated identically), but does so in a single event per field instead of per character. The test now runs in ~600ms (down from 3-7s) and passes 50/50 on a noisy CI-like load.

Flaky tests report payload:
[
  {
    "name": "UserForm::should save the user",
    "max_score": 0.2375,
    "occurrences": 1,
    "first_seen": "2026-05-05T04:18:53Z",
    "last_seen": "2026-05-05T04:18:53Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-05-05T04:18:53Z",
        "commit": "647fea1a7ce07030327a11a64c7e83eebafbd620",
        "run_id": "25357040669",
        "score": 0.2375
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/Users/UserForm.test.jsx",
    "slug": "user-form",
    "branch": "fix-flaky/user-form"
  }
]

# Description

Please include a summary of the changes and the related issue, if it exists. 
Also, include relevant motivation and context for this PR. List any dependencies that are required for this change.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [ ] **DONE**
