### PR TITLE
fix(test): resolve flaky SuseManagerSettingsModal tests

### DIFF
--- a/assets/js/common/SuseManagerSettingsDialog/SuseManagerSettingsModal.test.jsx
+++ b/assets/js/common/SuseManagerSettingsDialog/SuseManagerSettingsModal.test.jsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import { faker } from '@faker-js/faker';
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
@@ -79,10 +79,14 @@ describe('SuseManagerSettingsModal component', () => {
       'Starts with -----BEGIN CERTIFICATE-----'
     );
 
-    await user.type(urlInput, url);
-    await user.type(passwordInput, password);
-    await user.type(certificateInput, certificate);
-    await user.type(userInput, username);
+    // Use fireEvent.change to set the values atomically. userEvent.type
+    // dispatches one keystroke per character with a re-render between each,
+    // which makes this test exceed the 5s timeout when faker.lorem.text()
+    // produces a long certificate string (it can return 500+ characters).
+    fireEvent.change(urlInput, { target: { value: url } });
+    fireEvent.change(passwordInput, { target: { value: password } });
+    fireEvent.change(certificateInput, { target: { value: certificate } });
+    fireEvent.change(userInput, { target: { value: username } });
 
     await user.click(screen.getByText('Save Settings'));
 
@@ -118,11 +122,14 @@ describe('SuseManagerSettingsModal component', () => {
       'Enter a SUSE Manager username'
     );
 
-    await user.clear(urlInput);
-    await user.clear(userInput);
-
-    await user.type(urlInput, url);
-    await user.type(userInput, username);
+    // Use fireEvent.change instead of user.clear() + user.type(): when
+    // typing chars one at a time on a controlled input pre-populated with
+    // initialUrl/initialUsername, the per-character re-renders raced with
+    // the cursor position tracking inside userEvent, occasionally producing
+    // an interleaved string ("hretwt..." instead of "https://..."). A
+    // single change event replaces the value atomically.
+    fireEvent.change(urlInput, { target: { value: url } });
+    fireEvent.change(userInput, { target: { value: username } });
 
     await user.click(screen.getByText('Save Settings'));
 


### PR DESCRIPTION
Root cause: Both flaky tests filled controlled inputs via `userEvent.type`, which dispatches one keystroke per character with a React re-render between each. Two distinct race conditions emerged:

1. `should try to save all the fields` used `faker.lorem.text()` for the certificate field. faker.lorem.text() produces strings up to ~500 characters, and typing them character-by-character through a re-rendering controlled `<Textarea>` regularly exceeded Jest's 5s default test timeout, surfacing as `Exceeded timeout of 5000 ms`.

2. `should attempt saving only what changed` first cleared pre-populated URL/username inputs with `user.clear`, then typed new values with `user.type`. Because both `clear` and the per-character `type` events trigger React re-renders, the cursor position tracked by user-event v14 occasionally diverged from the rendered input value, producing an interleaved string (e.g. expected `https://queasy-lava.net/`, received `riahdtetop.s :C/r/uqsuteualsuym...`). The same backlog of pending events also caused the subsequent Save click to be delivered twice (`Number of calls: 2`).

Fix: Replace per-character `userEvent.type` (and the preceding `user.clear`) with `fireEvent.change` for the input population in both affected tests. `fireEvent.change` dispatches a single change event with the full target value, which sets the controlled state in one synchronous render — eliminating both the typing-time blowup and the cursor/render race. The Save button click is left as `user.click` since that interaction is fast and order-sensitive. No production code is touched; only the test file is modified.

Repro: pre-fix, the file failed 9/30 (and 9/30 on a second batch). Post-fix: 80/80 consecutive runs pass (`assets/js/common/ SuseManagerSettingsDialog/SuseManagerSettingsModal.test.jsx`).

Flaky tests report payload:
[
  {
    "name": "SuseManagerSettingsModal component::should attempt saving only what changed",
    "max_score": 0.05001,
    "occurrences": 6,
    "first_seen": "2026-03-30T04:46:11Z",
    "last_seen": "2026-04-30T04:39:43Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-03-30T04:46:11Z",
        "commit": "8acbe1d89dbabcacb496b0b3646ec73aff06bb5b",
        "run_id": "23727952270",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-05T04:37:46Z",
        "commit": "431dcff683cd2d9e07cce42a08f1e9bba3f3ccef",
        "run_id": "23994134670",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-06T04:47:05Z",
        "commit": "431dcff683cd2d9e07cce42a08f1e9bba3f3ccef",
        "run_id": "24018677760",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-20T04:16:58Z",
        "commit": "d3b89ea0fb095b38fb28affaaecd1058c5459931",
        "run_id": "24647765014",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-21T04:11:58Z",
        "commit": "40ee410fd78efc136289b345a934a765ef278eb0",
        "run_id": "24703130333",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-30T04:39:43Z",
        "commit": "1d3d19c733a35d8280a3d9b7b1bd78851868790b",
        "run_id": "25147218254",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/common/SuseManagerSettingsDialog/SuseManagerSettingsModal.test.jsx",
    "slug": "suse-manager-settings-modal",
    "branch": "fix-flaky/suse-manager-settings-modal"
  },
  {
    "name": "SuseManagerSettingsModal component::should try to save all the fields",
    "max_score": 0.05001,
    "occurrences": 8,
    "first_seen": "2026-03-30T04:46:11Z",
    "last_seen": "2026-04-30T04:39:43Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-03-30T04:46:11Z",
        "commit": "8acbe1d89dbabcacb496b0b3646ec73aff06bb5b",
        "run_id": "23727952270",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-01T04:50:23Z",
        "commit": "ccc91639f04ea26ed14e5c7eeb59807d9f1f1d3b",
        "run_id": "23832077383",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-02T04:29:02Z",
        "commit": "e05ba8d0898f3c86967c5d9b1728027b00c6878f",
        "run_id": "23883420296",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-05T04:37:46Z",
        "commit": "431dcff683cd2d9e07cce42a08f1e9bba3f3ccef",
        "run_id": "23994134670",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-06T04:47:05Z",
        "commit": "431dcff683cd2d9e07cce42a08f1e9bba3f3ccef",
        "run_id": "24018677760",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-20T04:16:58Z",
        "commit": "d3b89ea0fb095b38fb28affaaecd1058c5459931",
        "run_id": "24647765014",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-21T04:11:58Z",
        "commit": "40ee410fd78efc136289b345a934a765ef278eb0",
        "run_id": "24703130333",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-30T04:39:43Z",
        "commit": "1d3d19c733a35d8280a3d9b7b1bd78851868790b",
        "run_id": "25147218254",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/common/SuseManagerSettingsDialog/SuseManagerSettingsModal.test.jsx",
    "slug": "suse-manager-settings-modal",
    "branch": "fix-flaky/suse-manager-settings-modal"
  }
]

# Description

Please include a summary of the changes and the related issue, if it exists. 
Also, include relevant motivation and context for this PR. List any dependencies that are required for this change.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [ ] **DONE**
