### PR TITLE
fix(test): resolve flaky NotificationBox "should display the title"

### DIFF
--- a/assets/js/common/NotificationBox/NotificationBox.test.jsx
+++ b/assets/js/common/NotificationBox/NotificationBox.test.jsx
@@ -59,9 +59,9 @@ describe('NotificationBox Component', () => {
   it('should display the title', () => {
     const icon = faker.color.human();
     const text = faker.lorem.paragraph();
-    const buttonText = faker.lorem.word();
+    const buttonText = `button-${faker.string.uuid()}`;
     const buttonOnClick = () => {};
-    const title = faker.lorem.word();
+    const title = `title-${faker.string.uuid()}`;
 
     render(
       <NotificationBox


### PR DESCRIPTION
Root cause: title and buttonText were both generated with faker.lorem.word(), which can return the same word (~0.08% probability). When that happened, screen.getByText(title) found two matching elements (title <p> and the Button label) and threw "Found multiple elements with the text".

Fix: prefix title and buttonText with faker.string.uuid() to guarantee uniqueness across the rendered DOM. Test-file change only.

Flaky tests report payload:
[
  {
    "name": "NotificationBox Component::should display the title",
    "max_score": 0.5,
    "occurrences": 1,
    "first_seen": "2026-04-19T04:13:51Z",
    "last_seen": "2026-04-19T04:13:51Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-19T04:13:51Z",
        "commit": "d3b89ea0fb095b38fb28affaaecd1058c5459931",
        "run_id": "24620463069",
        "score": 0.5
      }
    ],
    "status": "pending",
    "test_file": "assets/js/common/NotificationBox/NotificationBox.test.jsx",
    "slug": "notification-box",
    "branch": "fix-flaky/notification-box"
  }
]

# Description

Please include a summary of the changes and the related issue, if it exists. 
Also, include relevant motivation and context for this PR. List any dependencies that are required for this change.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [ ] **DONE**
