### PR TITLE
fix(test): resolve flaky AdvisoryDetails "displays CVEs with a valid …

### DIFF
--- a/assets/js/lib/test-utils/factories/advisoryErrata.js
+++ b/assets/js/lib/test-utils/factories/advisoryErrata.js
@@ -31,11 +31,8 @@ const fixMapFactory = Factory.define(({ transientParams }) => {
 });
 
 export const cveFactory = Factory.define(
-  () =>
-    `CVE-${faker.number.int({ min: 1991, max: 2024 })}-${faker.number.int({
-      min: 0,
-      max: 9999,
-    })}`
+  ({ sequence }) =>
+    `CVE-${faker.number.int({ min: 1991, max: 2024 })}-${sequence}`
 );
 
 export const advisoryErrataFactory = Factory.define(({ params }) => ({


### PR DESCRIPTION
…link"

Root cause: cveFactory generated IDs as `CVE-YYYY-NNNN` using two random integers (year 1991-2024, suffix 0-9999), giving only ~340k possible values. With buildList(N) for N in [2,10] (or default 10), birthday- problem collisions produced duplicate CVE IDs. The component renders one anchor per CVE, so duplicates caused screen.getByText(cve) to throw (multiple elements found).

Fix: switch the suffix from a random number to Fishery's monotonically incrementing `sequence`, guaranteeing each generated CVE ID is unique across calls.

Verification: 100/100 passes for the targeted test, 9/9 passes for the full file.

Flaky tests report payload:
[
  {
    "name": "AdvisoryDetails::displays CVEs with a valid link",
    "max_score": 0.05001,
    "occurrences": 2,
    "first_seen": "2026-04-15T04:06:46Z",
    "last_seen": "2026-04-17T04:10:10Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-15T04:06:46Z",
        "commit": "8360d6b6b5a0426e4e554ed7f3490430c5b87d10",
        "run_id": "24435409340",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-17T04:10:10Z",
        "commit": "315db7fc47e870e5494c263354f648081a07d4b7",
        "run_id": "24546762461",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/AdvisoryDetails/AdvisoryDetails.test.jsx",
    "slug": "advisory-details",
    "branch": "fix-flaky/advisory-details"
  }
]

# Description

Please include a summary of the changes and the related issue, if it exists. 
Also, include relevant motivation and context for this PR. List any dependencies that are required for this change.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [ ] **DONE**
