### PR TITLE
fix(test): resolve flaky checksUtils "should get host expectation sta…

### DIFF
--- a/assets/js/pages/ExecutionResults/checksUtils.test.js
+++ b/assets/js/pages/ExecutionResults/checksUtils.test.js
@@ -173,10 +173,20 @@ describe('checksUtils', () => {
   });
 
   it('should get host expectation statements results', () => {
+    // Use explicit unique names to avoid collisions across factories.
+    // Each catalogExpect*Factory has its own sequence counter that resets
+    // per factory, so two factories may emit the same `${word}_${seq}`
+    // name when their sequences happen to align (notably when this test
+    // runs in isolation via `-t` and all factory sequences start at 1).
+    const expectationNames = Array.from({ length: 5 }, () =>
+      faker.string.uuid()
+    );
     const expectations = [].concat(
-      catalogExpectExpectationFactory.buildList(3),
-      catalogExpectSameExpectationFactory.build(),
-      catalogExpectEnumExpectationFactory.build()
+      catalogExpectExpectationFactory.build({ name: expectationNames[0] }),
+      catalogExpectExpectationFactory.build({ name: expectationNames[1] }),
+      catalogExpectExpectationFactory.build({ name: expectationNames[2] }),
+      catalogExpectSameExpectationFactory.build({ name: expectationNames[3] }),
+      catalogExpectEnumExpectationFactory.build({ name: expectationNames[4] })
     );
 
     const [


### PR DESCRIPTION
…tements results"

Root cause: each catalogExpect{,Same,Enum}ExpectationFactory has its own `sequence` counter and produces names of the form `${faker.lorem.word()}_${sequence}`. When the test runs in isolation (e.g. via `jest -t`), the EXPECT_SAME and EXPECT_ENUM factories both start at sequence 1, so a faker.lorem.word() collision yields identical names for `expectation4` and `expectation5`. `getHostExpectationStatementsResults` then resolves expectation5's evaluation via a name-based `find()`, returning the EXPECT_SAME evaluation (built with the colliding name) instead of the EXPECT_ENUM one and the assertion fails.

Fix: build each catalog expectation with an explicit faker.string.uuid() name so the five expectation names are guaranteed unique. No production code change.

Flaky tests report payload:
[
  {
    "name": "checksUtils::should get host expectation statements results",
    "max_score": 0.02501,
    "occurrences": 2,
    "first_seen": "2026-04-26T04:23:19Z",
    "last_seen": "2026-05-08T04:21:10Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-26T04:23:19Z",
        "commit": "f003f86717bdf66015b8712a9443c63b345089d1",
        "run_id": "24947852183",
        "score": 0.02501
      },
      {
        "timestamp": "2026-05-08T04:21:10Z",
        "commit": "17d6113a9cf5bc4e6a50d78db1b2e0288d062407",
        "run_id": "25535897343",
        "score": 0.02501
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/ExecutionResults/checksUtils.test.js",
    "slug": "checks-utils",
    "branch": "fix-flaky/checks-utils"
  }
]

# Description

Please include a summary of the changes and the related issue, if it exists. 
Also, include relevant motivation and context for this PR. List any dependencies that are required for this change.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [ ] **DONE**
