### PR TITLE
fix(test): resolve flaky DeregistrationModal tests

### DIFF
--- a/assets/js/pages/DeregistrationModal/DeregistrationModal.test.jsx
+++ b/assets/js/pages/DeregistrationModal/DeregistrationModal.test.jsx
@@ -3,16 +3,19 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { faker } from '@faker-js/faker';
 
 import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model/sapSystems';
-import { generateSid } from '@lib/test-utils/factories';
 
 import DeregistrationModal from '.';
 
 describe('Deregistration Modal component', () => {
   it('should render a host deregistration modal correctly', async () => {
-    const hostname = faker.person.firstName();
+    // Use a deterministic hostname that cannot appear as a substring in the
+    // modal body, button labels, or any other rendered text. Random faker
+    // names like "Will", "Trent", "Al" or "Ed" used to collide with words in
+    // the body ("will", "Trento", "all", "discovered"), causing
+    // `findByText(hostname, { exact: false })` to match multiple nodes.
+    const hostname = 'host-xyz-1234567890';
 
     render(
       <DeregistrationModal
@@ -37,8 +40,13 @@ describe('Deregistration Modal component', () => {
   });
 
   it('should render an application instance deregistration modal correctly', async () => {
-    const sid = generateSid();
-    const instanceNumber = '00';
+    // Use deterministic identifiers that cannot collide with any substring of
+    // the rendered body text. A randomly generated 3-char alphanumeric sid
+    // (e.g. "ASC", "SCS", "TIO") would occasionally appear inside the body
+    // string ("ASCS instance", "Application", "deregistration"), making
+    // `findByText(sid, { exact: false })` match multiple nodes intermittently.
+    const sid = '999';
+    const instanceNumber = '88';
 
     render(
       <DeregistrationModal
@@ -63,8 +71,11 @@ describe('Deregistration Modal component', () => {
   });
 
   it('should render a database instance deregistration modal correctly', async () => {
-    const sid = generateSid();
-    const instanceNumber = '00';
+    // See note in the application-instance test above; the same flakiness
+    // applied here when the random sid happened to be a substring of the
+    // modal body (e.g. "ATA" in "database", "PRI" in "Primary").
+    const sid = '777';
+    const instanceNumber = '88';
 
     render(
       <DeregistrationModal


### PR DESCRIPTION
Root cause: each test used `findByText(value, { exact: false })` with a randomly generated value (faker `firstName()` for the host test, `generateSid()` -> 3-char uppercase alphanumeric for the database and application instance tests). Because `exact: false` performs a case-insensitive substring match, the random value occasionally appeared inside the modal body (e.g. `Will`/`Trent` in "will cause Trento"; `ATA` in "database"; `SCS`/`PRI` in "ASCS instance"/"Primary"). When that happened, the matcher resolved to multiple nodes and threw, intermittently failing the suite (~0.13-0.19% per test).

Fix: replace the random hostname/sid values with deterministic strings that cannot be substrings of the rendered body or button labels. Tests still cover the same rendering behaviour and now pass 30/30.

Flaky tests report payload:
[
  {
    "name": "Deregistration Modal component::should render a host deregistration modal correctly",
    "max_score": 0.05001,
    "occurrences": 6,
    "first_seen": "2026-04-05T04:37:46Z",
    "last_seen": "2026-05-12T04:44:48Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-05T04:37:46Z",
        "commit": "431dcff683cd2d9e07cce42a08f1e9bba3f3ccef",
        "run_id": "23994134670",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-11T04:20:51Z",
        "commit": "8b846349ed7ab730785cb8395f839a927bde9b76",
        "run_id": "24274249598",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-15T04:06:46Z",
        "commit": "8360d6b6b5a0426e4e554ed7f3490430c5b87d10",
        "run_id": "24435409340",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-19T04:13:51Z",
        "commit": "d3b89ea0fb095b38fb28affaaecd1058c5459931",
        "run_id": "24620463069",
        "score": 0.05001
      },
      {
        "timestamp": "2026-05-01T04:54:29Z",
        "commit": "aed802d8ce1e30739e2fdb764731615bef86b31c",
        "run_id": "25202443824",
        "score": 0.02501
      },
      {
        "timestamp": "2026-05-12T04:44:48Z",
        "commit": "2cdec8baa70752e99bb973e0aef129a1ff26f4e8",
        "run_id": "25713277735",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/DeregistrationModal/DeregistrationModal.test.jsx",
    "slug": "deregistration-modal",
    "branch": "fix-flaky/deregistration-modal"
  },
  {
    "name": "Deregistration Modal component::should render a database instance deregistration modal correctly",
    "max_score": 0.5,
    "occurrences": 4,
    "first_seen": "2026-04-05T04:37:46Z",
    "last_seen": "2026-05-02T04:18:22Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-05T04:37:46Z",
        "commit": "431dcff683cd2d9e07cce42a08f1e9bba3f3ccef",
        "run_id": "23994134670",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-22T04:06:38Z",
        "commit": "289d8dfd6d86889b5fbbafde1f7f4dbd9a6b4233",
        "run_id": "24759173635",
        "score": 0.5
      },
      {
        "timestamp": "2026-04-29T04:29:50Z",
        "commit": "c75a8203543a097f7bd551d93a6b165626b58df8",
        "run_id": "25090465347",
        "score": 0.02501
      },
      {
        "timestamp": "2026-05-02T04:18:22Z",
        "commit": "aed802d8ce1e30739e2fdb764731615bef86b31c",
        "run_id": "25243272334",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/DeregistrationModal/DeregistrationModal.test.jsx",
    "slug": "deregistration-modal",
    "branch": "fix-flaky/deregistration-modal"
  },
  {
    "name": "Deregistration Modal component::should render an application instance deregistration modal correctly",
    "max_score": 0.02501,
    "occurrences": 2,
    "first_seen": "2026-04-15T04:06:46Z",
    "last_seen": "2026-04-22T04:06:38Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-15T04:06:46Z",
        "commit": "8360d6b6b5a0426e4e554ed7f3490430c5b87d10",
        "run_id": "24435409340",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-22T04:06:38Z",
        "commit": "289d8dfd6d86889b5fbbafde1f7f4dbd9a6b4233",
        "run_id": "24759173635",
        "score": 0.02501
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/DeregistrationModal/DeregistrationModal.test.jsx",
    "slug": "deregistration-modal",
    "branch": "fix-flaky/deregistration-modal"
  }
]

# Description

Please include a summary of the changes and the related issue, if it exists. 
Also, include relevant motivation and context for this PR. List any dependencies that are required for this change.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [ ] **DONE**
