### PR TITLE
fix(test): resolve flaky search/filter "should not match not included…

### DIFF
--- a/assets/js/lib/filter/index.test.js
+++ b/assets/js/lib/filter/index.test.js
@@ -28,10 +28,14 @@ describe('search', () => {
   });
 
   it('should not match not included words', () => {
-    const words = faker.word.words(2).split(' ');
+    // Use deterministic, mutually non-substring words to avoid faker
+    // occasionally producing pairs like ("afford", "for") or duplicates,
+    // where words[0] would actually contain words[1].
+    const haystack = 'alpha';
+    const needle = 'omega';
 
-    expect(containsSubstring(words[0], words[1])).toBe(false);
-    expect(containsSubstring('', words[1])).toBe(false);
+    expect(containsSubstring(haystack, needle)).toBe(false);
+    expect(containsSubstring('', needle)).toBe(false);
   });
 
   it('should match unicode in different forms', () => {


### PR DESCRIPTION
… words"

Root cause: the test generated two random words via faker.word.words(2) and asserted that words[0] does not contain words[1]. With ~0.35% probability per run, faker produced pairs where words[0] DID contain words[1] - either identical pairs (e.g. "as"/"as") or short words nested in longer ones (e.g. "afford"/"for", "soup"/"so"). The regularizeString includes() check then returned true and the assertion expecting false failed.

Fix: replace the random pair with two hardcoded, mutually non-substring words ("alpha" / "omega"). The contract being verified - that containsSubstring returns false for unrelated inputs and for an empty haystack with a non-empty needle - is deterministic and does not benefit from random word generation. Test-file change only; the production filter logic is untouched.

Flaky tests report payload:
[
  {
    "name": "search::should not match not included words",
    "max_score": 0.07001,
    "occurrences": 5,
    "first_seen": "2026-03-29T04:39:15Z",
    "last_seen": "2026-04-19T04:13:51Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-03-29T04:39:15Z",
        "commit": "8acbe1d89dbabcacb496b0b3646ec73aff06bb5b",
        "run_id": "23701274126",
        "score": 0.06196
      },
      {
        "timestamp": "2026-04-01T04:50:23Z",
        "commit": "ccc91639f04ea26ed14e5c7eeb59807d9f1f1d3b",
        "run_id": "23832077383",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-05T04:37:46Z",
        "commit": "431dcff683cd2d9e07cce42a08f1e9bba3f3ccef",
        "run_id": "23994134670",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-16T04:17:40Z",
        "commit": "116041531559de669d60a9c31a82770a55a6973a",
        "run_id": "24491207415",
        "score": 0.07001
      },
      {
        "timestamp": "2026-04-19T04:13:51Z",
        "commit": "d3b89ea0fb095b38fb28affaaecd1058c5459931",
        "run_id": "24620463069",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/lib/filter/index.test.js",
    "slug": "filter-index",
    "branch": "fix-flaky/filter-index"
  }
]

# Description

Please include a summary of the changes and the related issue, if it exists. 
Also, include relevant motivation and context for this PR. List any dependencies that are required for this change.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [ ] **DONE**
