### PR TITLE
fix(test): resolve flaky GenericSystemDetails tests

### DIFF
--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
@@ -42,11 +42,14 @@ import {
 } from './sapOperations';
 
 expect.extend({
-  toHaveMenuitem(operation, options) {
+  async toHaveMenuitem(operation, options) {
     const enabled = options?.enabled ?? false;
     let opItem;
     try {
-      opItem = screen.getByRole('menuitem', { name: operation });
+      // Use findByRole to wait for the menu (HeadlessUI Menu opens via
+      // floating-ui effects, so the menuitem may not be in the DOM
+      // synchronously after the click handler resolves).
+      opItem = await screen.findByRole('menuitem', { name: operation });
     } catch (error) {
       return {
         pass: false,
@@ -65,10 +68,10 @@ expect.extend({
     };
   },
 
-  toBeRunning(operation) {
+  async toBeRunning(operation) {
     let opItem;
     try {
-      opItem = screen.getByRole('menuitem', { name: operation });
+      opItem = await screen.findByRole('menuitem', { name: operation });
     } catch (error) {
       return {
         pass: false,
@@ -480,7 +483,7 @@ describe('GenericSystemDetails', () => {
 
       await user.click(screen.getByRole('button', { name: 'Operations' }));
 
-      expect(operation).toHaveMenuitem({ enabled });
+      await expect(operation).toHaveMenuitem({ enabled });
     }
   );
 
@@ -533,7 +536,7 @@ describe('GenericSystemDetails', () => {
 
       await user.click(screen.getByRole('button', { name: 'Operations' }));
 
-      expect(operation).toHaveMenuitem({ enabled });
+      await expect(operation).toHaveMenuitem({ enabled });
     }
   );
 
@@ -618,11 +621,11 @@ describe('GenericSystemDetails', () => {
 
       await user.click(siteOpButton1);
 
-      expect(operation).toHaveMenuitem({ enabled });
+      await expect(operation).toHaveMenuitem({ enabled });
 
       await user.click(siteOpButton2);
 
-      const opItem2 = screen.getByRole('menuitem', {
+      const opItem2 = await screen.findByRole('menuitem', {
         name: operation,
       });
 
@@ -684,7 +687,7 @@ describe('GenericSystemDetails', () => {
 
       await user.click(opButton);
 
-      expect(menuItemText).toBeRunning(operation);
+      await expect(menuItemText).toBeRunning(operation);
     }
   );
 
@@ -750,7 +753,7 @@ describe('GenericSystemDetails', () => {
 
       await user.click(screen.getByRole('button', { name: 'Operations' }));
 
-      expect(menuItemText).toBeRunning(operation);
+      await expect(menuItemText).toBeRunning(operation);
     }
   );
 
@@ -824,10 +827,10 @@ describe('GenericSystemDetails', () => {
       const siteOpButton2 = getByRoleSite2('button');
 
       await user.click(siteOpButton1);
-      expect(menuItemText).toBeRunning(operation);
+      await expect(menuItemText).toBeRunning(operation);
 
       await user.click(siteOpButton2);
-      expect(menuItemText).toHaveMenuitem({ enabled: false });
+      await expect(menuItemText).toHaveMenuitem({ enabled: false });
     }
   );
 
@@ -879,8 +882,8 @@ describe('GenericSystemDetails', () => {
 
       await user.click(opButton);
 
-      expect('Start instance').toHaveMenuitem({ enabled: false });
-      expect('Stop instance').toHaveMenuitem({ enabled: false });
+      await expect('Start instance').toHaveMenuitem({ enabled: false });
+      await expect('Stop instance').toHaveMenuitem({ enabled: false });
     }
   );
 
@@ -921,8 +924,8 @@ describe('GenericSystemDetails', () => {
     const opButton = screen.getByRole('button', { name: 'Operations' });
     await user.click(opButton);
 
-    expect('Start system').toHaveMenuitem({ enabled: false });
-    expect('Stop system').toHaveMenuitem({ enabled: false });
+    await expect('Start system').toHaveMenuitem({ enabled: false });
+    await expect('Stop system').toHaveMenuitem({ enabled: false });
   });
 
   it('should show forbidden operation modal', async () => {
@@ -1223,7 +1226,7 @@ describe('GenericSystemDetails', () => {
 
         await user.click(opButton);
 
-        expect(label).toHaveMenuitem({ enabled: !forbidden });
+        await expect(label).toHaveMenuitem({ enabled: !forbidden });
       }
     );
 
@@ -1329,7 +1332,7 @@ describe('GenericSystemDetails', () => {
 
         await user.click(screen.getByRole('button', { name: 'Operations' }));
 
-        expect(label).toHaveMenuitem({ enabled: !forbidden });
+        await expect(label).toHaveMenuitem({ enabled: !forbidden });
       }
     );
 
@@ -1396,7 +1399,7 @@ describe('GenericSystemDetails', () => {
         const siteOpButton = getByRole('button');
         await user.click(siteOpButton);
 
-        expect(label).toHaveMenuitem({ enabled: !forbidden });
+        await expect(label).toHaveMenuitem({ enabled: !forbidden });
       }
     );
   });


### PR DESCRIPTION
Root cause: The custom Jest matchers `toHaveMenuitem` and `toBeRunning` called `screen.getByRole('menuitem', ...)` synchronously immediately after `await user.click(...)` opened a HeadlessUI Menu. HeadlessUI's Menu renders MenuItems via floating-ui anchor positioning, which performs additional effect cycles before the items appear in the DOM, so the synchronous query intermittently failed.

Fix: Made both matchers async and switched to `screen.findByRole`, which waits for the menuitem to appear. All call sites now use `await expect(...)` so Jest awaits the asynchronous matcher result. No production code was modified.

Flaky tests resolved: 29.

Flaky tests report payload:
[
  {
    "name": "GenericSystemDetails::should show database site operation Stop database with enabled state as true",
    "max_score": 0.09501,
    "occurrences": 9,
    "first_seen": "2026-04-03T04:30:19Z",
    "last_seen": "2026-05-10T04:53:02Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-03T04:30:19Z",
        "commit": "b8ad8ce4166e05da624b4be4751564144bbe6d34",
        "run_id": "23933447473",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-08T04:36:50Z",
        "commit": "c1c8179aea75eb25e7a1b991435fe595884aa945",
        "run_id": "24117491595",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-13T05:00:24Z",
        "commit": "8b846349ed7ab730785cb8395f839a927bde9b76",
        "run_id": "24326061637",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-16T04:17:40Z",
        "commit": "116041531559de669d60a9c31a82770a55a6973a",
        "run_id": "24491207415",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-27T04:27:10Z",
        "commit": "f003f86717bdf66015b8712a9443c63b345089d1",
        "run_id": "24976109847",
        "score": 0.05001
      },
      {
        "timestamp": "2026-05-01T04:54:29Z",
        "commit": "aed802d8ce1e30739e2fdb764731615bef86b31c",
        "run_id": "25202443824",
        "score": 0.05001
      },
      {
        "timestamp": "2026-05-03T04:46:41Z",
        "commit": "aed802d8ce1e30739e2fdb764731615bef86b31c",
        "run_id": "25269875694",
        "score": 0.05001
      },
      {
        "timestamp": "2026-05-07T04:42:28Z",
        "commit": "279c34655d05ec9b9b78dceb094adbb951d5583a",
        "run_id": "25475976804",
        "score": 0.05001
      },
      {
        "timestamp": "2026-05-10T04:53:02Z",
        "commit": "ed080da4b45c0a477a9cb84d82aa87a7a9cf7a97",
        "run_id": "25619877756",
        "score": 0.09501
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails::should show instance operation sap_instance_start in running state",
    "max_score": 0.09051,
    "occurrences": 9,
    "first_seen": "2026-04-03T04:30:19Z",
    "last_seen": "2026-05-08T04:21:10Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-03T04:30:19Z",
        "commit": "b8ad8ce4166e05da624b4be4751564144bbe6d34",
        "run_id": "23933447473",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-06T04:47:05Z",
        "commit": "431dcff683cd2d9e07cce42a08f1e9bba3f3ccef",
        "run_id": "24018677760",
        "score": 0.09051
      },
      {
        "timestamp": "2026-04-10T04:47:52Z",
        "commit": "54bd084c152259334fd242f53ab63870b360ad6d",
        "run_id": "24226469869",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-23T04:13:21Z",
        "commit": "54feddca92f5302bf6ad90fd3e708b6508fc6392",
        "run_id": "24815824984",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-26T04:23:19Z",
        "commit": "f003f86717bdf66015b8712a9443c63b345089d1",
        "run_id": "24947852183",
        "score": 0.05001
      },
      {
        "timestamp": "2026-05-03T04:46:41Z",
        "commit": "aed802d8ce1e30739e2fdb764731615bef86b31c",
        "run_id": "25269875694",
        "score": 0.05001
      },
      {
        "timestamp": "2026-05-04T04:46:45Z",
        "commit": "aed802d8ce1e30739e2fdb764731615bef86b31c",
        "run_id": "25301077266",
        "score": 0.05001
      },
      {
        "timestamp": "2026-05-05T04:18:53Z",
        "commit": "647fea1a7ce07030327a11a64c7e83eebafbd620",
        "run_id": "25357040669",
        "score": 0.05001
      },
      {
        "timestamp": "2026-05-08T04:21:10Z",
        "commit": "17d6113a9cf5bc4e6a50d78db1b2e0288d062407",
        "run_id": "25535897343",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails::should show database site operation database_stop in running state",
    "max_score": 0.1001,
    "occurrences": 8,
    "first_seen": "2026-04-01T04:50:23Z",
    "last_seen": "2026-05-04T04:46:45Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-01T04:50:23Z",
        "commit": "ccc91639f04ea26ed14e5c7eeb59807d9f1f1d3b",
        "run_id": "23832077383",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-02T04:29:02Z",
        "commit": "e05ba8d0898f3c86967c5d9b1728027b00c6878f",
        "run_id": "23883420296",
        "score": 0.1001
      },
      {
        "timestamp": "2026-04-03T04:30:19Z",
        "commit": "b8ad8ce4166e05da624b4be4751564144bbe6d34",
        "run_id": "23933447473",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-06T04:47:05Z",
        "commit": "431dcff683cd2d9e07cce42a08f1e9bba3f3ccef",
        "run_id": "24018677760",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-07T04:33:51Z",
        "commit": "d8cc7cd8b9b4c08109924a5c859ed816111cf639",
        "run_id": "24064001400",
        "score": 0.06823
      },
      {
        "timestamp": "2026-04-12T04:49:17Z",
        "commit": "8b846349ed7ab730785cb8395f839a927bde9b76",
        "run_id": "24298708972",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-14T04:46:27Z",
        "commit": "d5c0383d3dc9d8bce172fb437441306226427928",
        "run_id": "24380994607",
        "score": 0.05001
      },
      {
        "timestamp": "2026-05-04T04:46:45Z",
        "commit": "aed802d8ce1e30739e2fdb764731615bef86b31c",
        "run_id": "25301077266",
        "score": 0.02501
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails::should show instance operations",
    "max_score": 0.1153,
    "occurrences": 7,
    "first_seen": "2026-03-29T04:39:15Z",
    "last_seen": "2026-05-11T05:05:10Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-03-29T04:39:15Z",
        "commit": "8acbe1d89dbabcacb496b0b3646ec73aff06bb5b",
        "run_id": "23701274126",
        "score": 0.05001
      },
      {
        "timestamp": "2026-03-30T04:46:11Z",
        "commit": "8acbe1d89dbabcacb496b0b3646ec73aff06bb5b",
        "run_id": "23727952270",
        "score": 0.1153
      },
      {
        "timestamp": "2026-04-10T04:47:52Z",
        "commit": "54bd084c152259334fd242f53ab63870b360ad6d",
        "run_id": "24226469869",
        "score": 0.05001
      },
      {
        "timestamp": "2026-05-05T04:18:53Z",
        "commit": "647fea1a7ce07030327a11a64c7e83eebafbd620",
        "run_id": "25357040669",
        "score": 0.05001
      },
      {
        "timestamp": "2026-05-07T04:42:28Z",
        "commit": "279c34655d05ec9b9b78dceb094adbb951d5583a",
        "run_id": "25475976804",
        "score": 0.05001
      },
      {
        "timestamp": "2026-05-10T04:53:02Z",
        "commit": "ed080da4b45c0a477a9cb84d82aa87a7a9cf7a97",
        "run_id": "25619877756",
        "score": 0.02501
      },
      {
        "timestamp": "2026-05-11T05:05:10Z",
        "commit": "ed080da4b45c0a477a9cb84d82aa87a7a9cf7a97",
        "run_id": "25650804239",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails::should disable instance operations if a an operation in the same host is running",
    "max_score": 0.05001,
    "occurrences": 7,
    "first_seen": "2026-04-10T04:47:52Z",
    "last_seen": "2026-05-12T04:44:48Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-10T04:47:52Z",
        "commit": "54bd084c152259334fd242f53ab63870b360ad6d",
        "run_id": "24226469869",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-11T04:20:51Z",
        "commit": "8b846349ed7ab730785cb8395f839a927bde9b76",
        "run_id": "24274249598",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-12T04:49:17Z",
        "commit": "8b846349ed7ab730785cb8395f839a927bde9b76",
        "run_id": "24298708972",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-21T04:11:58Z",
        "commit": "40ee410fd78efc136289b345a934a765ef278eb0",
        "run_id": "24703130333",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-23T04:13:21Z",
        "commit": "54feddca92f5302bf6ad90fd3e708b6508fc6392",
        "run_id": "24815824984",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-28T04:40:35Z",
        "commit": "c75a8203543a097f7bd551d93a6b165626b58df8",
        "run_id": "25033785516",
        "score": 0.02501
      },
      {
        "timestamp": "2026-05-12T04:44:48Z",
        "commit": "2cdec8baa70752e99bb973e0aef129a1ff26f4e8",
        "run_id": "25713277735",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails::should show instance operation sap_instance_stop in running state",
    "max_score": 0.05001,
    "occurrences": 6,
    "first_seen": "2026-04-12T04:49:17Z",
    "last_seen": "2026-05-06T04:41:39Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-12T04:49:17Z",
        "commit": "8b846349ed7ab730785cb8395f839a927bde9b76",
        "run_id": "24298708972",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-15T04:06:46Z",
        "commit": "8360d6b6b5a0426e4e554ed7f3490430c5b87d10",
        "run_id": "24435409340",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-24T04:16:50Z",
        "commit": "4d018d598251ab302f8515535a0582af06fcc0e4",
        "run_id": "24871468908",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-30T04:39:43Z",
        "commit": "1d3d19c733a35d8280a3d9b7b1bd78851868790b",
        "run_id": "25147218254",
        "score": 0.05001
      },
      {
        "timestamp": "2026-05-03T04:46:41Z",
        "commit": "aed802d8ce1e30739e2fdb764731615bef86b31c",
        "run_id": "25269875694",
        "score": 0.05001
      },
      {
        "timestamp": "2026-05-06T04:41:39Z",
        "commit": "7832496cee58abd9dda40526511c3fca6297c14e",
        "run_id": "25416335393",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails::should show database site operation Start database with enabled state as true",
    "max_score": 0.25,
    "occurrences": 5,
    "first_seen": "2026-03-30T04:46:11Z",
    "last_seen": "2026-05-10T04:53:02Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-03-30T04:46:11Z",
        "commit": "8acbe1d89dbabcacb496b0b3646ec73aff06bb5b",
        "run_id": "23727952270",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-10T04:47:52Z",
        "commit": "54bd084c152259334fd242f53ab63870b360ad6d",
        "run_id": "24226469869",
        "score": 0.05001
      },
      {
        "timestamp": "2026-05-05T04:18:53Z",
        "commit": "647fea1a7ce07030327a11a64c7e83eebafbd620",
        "run_id": "25357040669",
        "score": 0.25
      },
      {
        "timestamp": "2026-05-07T04:42:28Z",
        "commit": "279c34655d05ec9b9b78dceb094adbb951d5583a",
        "run_id": "25475976804",
        "score": 0.05001
      },
      {
        "timestamp": "2026-05-10T04:53:02Z",
        "commit": "ed080da4b45c0a477a9cb84d82aa87a7a9cf7a97",
        "run_id": "25619877756",
        "score": 0.02501
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails::should show database site operation database_start in running state",
    "max_score": 0.5,
    "occurrences": 4,
    "first_seen": "2026-04-20T04:16:58Z",
    "last_seen": "2026-05-11T05:05:10Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-20T04:16:58Z",
        "commit": "d3b89ea0fb095b38fb28affaaecd1058c5459931",
        "run_id": "24647765014",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-24T04:16:50Z",
        "commit": "4d018d598251ab302f8515535a0582af06fcc0e4",
        "run_id": "24871468908",
        "score": 0.05781
      },
      {
        "timestamp": "2026-04-27T04:27:10Z",
        "commit": "f003f86717bdf66015b8712a9443c63b345089d1",
        "run_id": "24976109847",
        "score": 0.5
      },
      {
        "timestamp": "2026-05-11T05:05:10Z",
        "commit": "ed080da4b45c0a477a9cb84d82aa87a7a9cf7a97",
        "run_id": "25650804239",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails::should show SAP system operation Stop system with enabled state as true",
    "max_score": 0.05001,
    "occurrences": 4,
    "first_seen": "2026-03-31T04:36:56Z",
    "last_seen": "2026-05-06T04:41:39Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-03-31T04:36:56Z",
        "commit": "0976bc51a7a041d5cc409131c821e8cdf001f9d3",
        "run_id": "23780262451",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-09T04:32:26Z",
        "commit": "54bd084c152259334fd242f53ab63870b360ad6d",
        "run_id": "24172058823",
        "score": 0.02501
      },
      {
        "timestamp": "2026-05-05T04:18:53Z",
        "commit": "647fea1a7ce07030327a11a64c7e83eebafbd620",
        "run_id": "25357040669",
        "score": 0.05001
      },
      {
        "timestamp": "2026-05-06T04:41:39Z",
        "commit": "7832496cee58abd9dda40526511c3fca6297c14e",
        "run_id": "25416335393",
        "score": 0.02501
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails::should show database site operation Start database with enabled state as false",
    "max_score": 0.05001,
    "occurrences": 4,
    "first_seen": "2026-04-03T04:30:19Z",
    "last_seen": "2026-05-12T04:44:48Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-03T04:30:19Z",
        "commit": "b8ad8ce4166e05da624b4be4751564144bbe6d34",
        "run_id": "23933447473",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-21T04:11:58Z",
        "commit": "40ee410fd78efc136289b345a934a765ef278eb0",
        "run_id": "24703130333",
        "score": 0.02501
      },
      {
        "timestamp": "2026-05-06T04:41:39Z",
        "commit": "7832496cee58abd9dda40526511c3fca6297c14e",
        "run_id": "25416335393",
        "score": 0.05001
      },
      {
        "timestamp": "2026-05-12T04:44:48Z",
        "commit": "2cdec8baa70752e99bb973e0aef129a1ff26f4e8",
        "run_id": "25713277735",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails::should show database site operation Stop database with enabled state as false",
    "max_score": 0.05001,
    "occurrences": 4,
    "first_seen": "2026-04-17T04:10:10Z",
    "last_seen": "2026-04-28T04:40:35Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-17T04:10:10Z",
        "commit": "315db7fc47e870e5494c263354f648081a07d4b7",
        "run_id": "24546762461",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-20T04:16:58Z",
        "commit": "d3b89ea0fb095b38fb28affaaecd1058c5459931",
        "run_id": "24647765014",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-27T04:27:10Z",
        "commit": "f003f86717bdf66015b8712a9443c63b345089d1",
        "run_id": "24976109847",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-28T04:40:35Z",
        "commit": "c75a8203543a097f7bd551d93a6b165626b58df8",
        "run_id": "25033785516",
        "score": 0.02501
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails::should disable systems operations if an instance operation is running",
    "max_score": 0.05001,
    "occurrences": 4,
    "first_seen": "2026-04-26T04:23:19Z",
    "last_seen": "2026-05-10T04:53:02Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-26T04:23:19Z",
        "commit": "f003f86717bdf66015b8712a9443c63b345089d1",
        "run_id": "24947852183",
        "score": 0.02501
      },
      {
        "timestamp": "2026-05-05T04:18:53Z",
        "commit": "647fea1a7ce07030327a11a64c7e83eebafbd620",
        "run_id": "25357040669",
        "score": 0.02501
      },
      {
        "timestamp": "2026-05-08T04:21:10Z",
        "commit": "17d6113a9cf5bc4e6a50d78db1b2e0288d062407",
        "run_id": "25535897343",
        "score": 0.02501
      },
      {
        "timestamp": "2026-05-10T04:53:02Z",
        "commit": "ed080da4b45c0a477a9cb84d82aa87a7a9cf7a97",
        "run_id": "25619877756",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails::should show SAP system operation Stop system with enabled state as false",
    "max_score": 0.5,
    "occurrences": 3,
    "first_seen": "2026-03-31T04:36:56Z",
    "last_seen": "2026-05-09T04:25:06Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-03-31T04:36:56Z",
        "commit": "0976bc51a7a041d5cc409131c821e8cdf001f9d3",
        "run_id": "23780262451",
        "score": 0.5
      },
      {
        "timestamp": "2026-05-08T04:21:10Z",
        "commit": "17d6113a9cf5bc4e6a50d78db1b2e0288d062407",
        "run_id": "25535897343",
        "score": 0.02501
      },
      {
        "timestamp": "2026-05-09T04:25:06Z",
        "commit": "ed080da4b45c0a477a9cb84d82aa87a7a9cf7a97",
        "run_id": "25591224392",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails \u203a forbidden actions::should forbid/authorize system/database operation database_start",
    "max_score": 0.05001,
    "occurrences": 3,
    "first_seen": "2026-04-01T04:50:23Z",
    "last_seen": "2026-04-27T04:27:10Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-01T04:50:23Z",
        "commit": "ccc91639f04ea26ed14e5c7eeb59807d9f1f1d3b",
        "run_id": "23832077383",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-17T04:10:10Z",
        "commit": "315db7fc47e870e5494c263354f648081a07d4b7",
        "run_id": "24546762461",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-27T04:27:10Z",
        "commit": "f003f86717bdf66015b8712a9443c63b345089d1",
        "run_id": "24976109847",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails::should show database operation Stop database with enabled state as false",
    "max_score": 0.05001,
    "occurrences": 3,
    "first_seen": "2026-04-04T04:17:02Z",
    "last_seen": "2026-05-08T04:21:10Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-04T04:17:02Z",
        "commit": "431dcff683cd2d9e07cce42a08f1e9bba3f3ccef",
        "run_id": "23970860615",
        "score": 0.05001
      },
      {
        "timestamp": "2026-05-05T04:18:53Z",
        "commit": "647fea1a7ce07030327a11a64c7e83eebafbd620",
        "run_id": "25357040669",
        "score": 0.02501
      },
      {
        "timestamp": "2026-05-08T04:21:10Z",
        "commit": "17d6113a9cf5bc4e6a50d78db1b2e0288d062407",
        "run_id": "25535897343",
        "score": 0.02501
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails \u203a forbidden actions::should forbid/authorize instance operation sap_instance_stop",
    "max_score": 0.05001,
    "occurrences": 3,
    "first_seen": "2026-04-21T04:11:58Z",
    "last_seen": "2026-05-11T05:05:10Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-21T04:11:58Z",
        "commit": "40ee410fd78efc136289b345a934a765ef278eb0",
        "run_id": "24703130333",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-24T04:16:50Z",
        "commit": "4d018d598251ab302f8515535a0582af06fcc0e4",
        "run_id": "24871468908",
        "score": 0.02501
      },
      {
        "timestamp": "2026-05-11T05:05:10Z",
        "commit": "ed080da4b45c0a477a9cb84d82aa87a7a9cf7a97",
        "run_id": "25650804239",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails::should show database operation Start database with enabled state as true",
    "max_score": 0.02501,
    "occurrences": 3,
    "first_seen": "2026-05-07T04:42:28Z",
    "last_seen": "2026-05-10T04:53:02Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-05-07T04:42:28Z",
        "commit": "279c34655d05ec9b9b78dceb094adbb951d5583a",
        "run_id": "25475976804",
        "score": 0.02501
      },
      {
        "timestamp": "2026-05-09T04:25:06Z",
        "commit": "ed080da4b45c0a477a9cb84d82aa87a7a9cf7a97",
        "run_id": "25591224392",
        "score": 0.02501
      },
      {
        "timestamp": "2026-05-10T04:53:02Z",
        "commit": "ed080da4b45c0a477a9cb84d82aa87a7a9cf7a97",
        "run_id": "25619877756",
        "score": 0.02501
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails \u203a forbidden actions::should forbid/authorize system/database operation database_stop",
    "max_score": 0.05001,
    "occurrences": 2,
    "first_seen": "2026-03-29T04:39:15Z",
    "last_seen": "2026-04-20T04:16:58Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-03-29T04:39:15Z",
        "commit": "8acbe1d89dbabcacb496b0b3646ec73aff06bb5b",
        "run_id": "23701274126",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-20T04:16:58Z",
        "commit": "d3b89ea0fb095b38fb28affaaecd1058c5459931",
        "run_id": "24647765014",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails::should show database operation Stop database with enabled state as true",
    "max_score": 0.05001,
    "occurrences": 2,
    "first_seen": "2026-03-31T04:36:56Z",
    "last_seen": "2026-04-09T04:32:26Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-03-31T04:36:56Z",
        "commit": "0976bc51a7a041d5cc409131c821e8cdf001f9d3",
        "run_id": "23780262451",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-09T04:32:26Z",
        "commit": "54bd084c152259334fd242f53ab63870b360ad6d",
        "run_id": "24172058823",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails \u203a forbidden actions::should forbid/authorize system/database operation sap_system_stop",
    "max_score": 0.05001,
    "occurrences": 2,
    "first_seen": "2026-04-16T04:17:40Z",
    "last_seen": "2026-04-19T04:13:51Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-16T04:17:40Z",
        "commit": "116041531559de669d60a9c31a82770a55a6973a",
        "run_id": "24491207415",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-19T04:13:51Z",
        "commit": "d3b89ea0fb095b38fb28affaaecd1058c5459931",
        "run_id": "24620463069",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails \u203a forbidden actions::should forbid/authorize database site operation database_stop",
    "max_score": 0.05001,
    "occurrences": 2,
    "first_seen": "2026-04-24T04:16:50Z",
    "last_seen": "2026-04-25T03:59:43Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-24T04:16:50Z",
        "commit": "4d018d598251ab302f8515535a0582af06fcc0e4",
        "run_id": "24871468908",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-25T03:59:43Z",
        "commit": "f003f86717bdf66015b8712a9443c63b345089d1",
        "run_id": "24921768160",
        "score": 0.02501
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails \u203a forbidden actions::should forbid/authorize instance operation sap_instance_start",
    "max_score": 0.05001,
    "occurrences": 1,
    "first_seen": "2026-05-08T04:21:10Z",
    "last_seen": "2026-05-08T04:21:10Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-05-08T04:21:10Z",
        "commit": "17d6113a9cf5bc4e6a50d78db1b2e0288d062407",
        "run_id": "25535897343",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails::should show SAP system operation Start system with enabled state as true",
    "max_score": 0.05001,
    "occurrences": 1,
    "first_seen": "2026-05-11T05:05:10Z",
    "last_seen": "2026-05-11T05:05:10Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-05-11T05:05:10Z",
        "commit": "ed080da4b45c0a477a9cb84d82aa87a7a9cf7a97",
        "run_id": "25650804239",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails::should disable instance operations if a system operation is running",
    "max_score": 0.05001,
    "occurrences": 1,
    "first_seen": "2026-05-12T04:44:48Z",
    "last_seen": "2026-05-12T04:44:48Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-05-12T04:44:48Z",
        "commit": "2cdec8baa70752e99bb973e0aef129a1ff26f4e8",
        "run_id": "25713277735",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails \u203a forbidden actions::should forbid/authorize system/database operation sap_system_start",
    "max_score": 0.02501,
    "occurrences": 1,
    "first_seen": "2026-03-31T04:36:56Z",
    "last_seen": "2026-03-31T04:36:56Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-03-31T04:36:56Z",
        "commit": "0976bc51a7a041d5cc409131c821e8cdf001f9d3",
        "run_id": "23780262451",
        "score": 0.02501
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails::should show database operation Start database with enabled state as false",
    "max_score": 0.02501,
    "occurrences": 1,
    "first_seen": "2026-03-31T04:36:56Z",
    "last_seen": "2026-03-31T04:36:56Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-03-31T04:36:56Z",
        "commit": "0976bc51a7a041d5cc409131c821e8cdf001f9d3",
        "run_id": "23780262451",
        "score": 0.02501
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails::should show system/database operation sap_system_stop in running state",
    "max_score": 0.02501,
    "occurrences": 1,
    "first_seen": "2026-04-25T03:59:43Z",
    "last_seen": "2026-04-25T03:59:43Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-25T03:59:43Z",
        "commit": "f003f86717bdf66015b8712a9443c63b345089d1",
        "run_id": "24921768160",
        "score": 0.02501
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails \u203a forbidden actions::should forbid/authorize database site operation database_start",
    "max_score": 0.02501,
    "occurrences": 1,
    "first_seen": "2026-05-10T04:53:02Z",
    "last_seen": "2026-05-10T04:53:02Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-05-10T04:53:02Z",
        "commit": "ed080da4b45c0a477a9cb84d82aa87a7a9cf7a97",
        "run_id": "25619877756",
        "score": 0.02501
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  },
  {
    "name": "GenericSystemDetails::should show system/database operation database_stop in running state",
    "max_score": 0.02501,
    "occurrences": 1,
    "first_seen": "2026-05-11T05:05:10Z",
    "last_seen": "2026-05-11T05:05:10Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-05-11T05:05:10Z",
        "commit": "ed080da4b45c0a477a9cb84d82aa87a7a9cf7a97",
        "run_id": "25650804239",
        "score": 0.02501
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx",
    "slug": "generic-system-details",
    "branch": "fix-flaky/generic-system-details"
  }
]

# Description

Please include a summary of the changes and the related issue, if it exists. 
Also, include relevant motivation and context for this PR. List any dependencies that are required for this change.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [ ] **DONE**
