### PR TITLE
fix(test): resolve flaky HanaClusterDetails "should display a host li…

### DIFF
--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.test.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.test.jsx
@@ -95,8 +95,15 @@ describe('HanaClusterDetails component', () => {
       details,
     } = clusterFactory.build();
 
-    const { nodes } = details;
-    const registeredClusterNode = nodes[0];
+    // Force unique, deterministic node names to avoid the small but non-zero
+    // chance that faker.animal.dog() produces the same name for both nodes,
+    // which would cause getByText below to match more than one element.
+    const uniqueNodes = details.nodes.map((node, index) => ({
+      ...node,
+      name: `registered-cluster-node-${index}`,
+    }));
+    const detailsWithUniqueNodes = { ...details, nodes: uniqueNodes };
+    const registeredClusterNode = uniqueNodes[0];
 
     const host = hostFactory.build({
       hostname: registeredClusterNode.name,
@@ -112,7 +119,7 @@ describe('HanaClusterDetails component', () => {
         clusterSids={[sid]}
         provider={provider}
         sapSystems={[]}
-        details={details}
+        details={detailsWithUniqueNodes}
         lastExecution={null}
       />
     );


### PR DESCRIPTION
…nk in the site details if the host is registered"

Root cause: the test built the cluster details with hanaClusterDetailsNodesFactory, which generates each node name with faker.animal.dog() (~497 distinct values). With 2 nodes per cluster, the names occasionally collide (birthday paradox). When they do, enrichNodes() in HanaClusterDetails attaches the same registered host to both nodes (matching by hostname), so both site tables render the same dog name as a HostLink. screen.getByText(name) then matches two elements and throws, causing the intermittent failure observed in CI (~5% rate).

Fix: in this test, override details.nodes to use deterministic, unique names ("registered-cluster-node-0" / "-1") before rendering. The registered host's hostname is set from the first overridden node, preserving the original intent while eliminating the random collision. No production code is changed.

Flaky tests report payload:
[
  {
    "name": "HanaClusterDetails component::should display a host link in the site details if the host is registered",
    "max_score": 0.05001,
    "occurrences": 4,
    "first_seen": "2026-04-01T04:50:23Z",
    "last_seen": "2026-05-09T04:25:06Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-01T04:50:23Z",
        "commit": "ccc91639f04ea26ed14e5c7eeb59807d9f1f1d3b",
        "run_id": "23832077383",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-17T04:10:10Z",
        "commit": "315db7fc47e870e5494c263354f648081a07d4b7",
        "run_id": "24546762461",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-24T04:16:50Z",
        "commit": "4d018d598251ab302f8515535a0582af06fcc0e4",
        "run_id": "24871468908",
        "score": 0.02501
      },
      {
        "timestamp": "2026-05-09T04:25:06Z",
        "commit": "ed080da4b45c0a477a9cb84d82aa87a7a9cf7a97",
        "run_id": "25591224392",
        "score": 0.02501
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/ClusterDetails/HanaClusterDetails.test.jsx",
    "slug": "hana-cluster-details",
    "branch": "fix-flaky/hana-cluster-details"
  }
]

# Description

Please include a summary of the changes and the related issue, if it exists. 
Also, include relevant motivation and context for this PR. List any dependencies that are required for this change.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [ ] **DONE**
