### PR TITLE
fix(test): resolve flaky HostDetails tests

### DIFF
--- a/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { act, screen, waitFor, within } from '@testing-library/react';
+import { act, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import 'intersection-observer';
 import '@testing-library/jest-dom';
@@ -441,9 +441,11 @@ describe('HostDetails component', () => {
 
   describe('last execution overview', () => {
     it('should be displayed when lastExecution has data inside', () => {
-      const passingCount = faker.number.int(100);
-      const warningCount = faker.number.int(100);
-      const criticalCount = faker.number.int(100);
+      // Use distinct values to avoid `getByText` matching multiple elements
+      // when faker happens to generate the same number for two of the counts.
+      const passingCount = 11;
+      const warningCount = 22;
+      const criticalCount = 33;
 
       const lastExecution = {
         data: {
@@ -464,6 +466,8 @@ describe('HostDetails component', () => {
       );
 
       expect(screen.getByText(passingCount)).toBeInTheDocument();
+      expect(screen.getByText(warningCount)).toBeInTheDocument();
+      expect(screen.getByText(criticalCount)).toBeInTheDocument();
       expect(screen.getByText('11 Jan 2024, 13:30:00')).toBeInTheDocument();
     });
 
@@ -527,7 +531,9 @@ describe('HostDetails component', () => {
 
         await user.click(operationsButton);
 
-        const menuItem = screen.getByRole('menuitem', {
+        // Use findByRole because the headless-ui v2 menu mounts/positions
+        // its items asynchronously after the click resolves.
+        const menuItem = await screen.findByRole('menuitem', {
           name: menuEntry,
         });
 
@@ -560,9 +566,9 @@ describe('HostDetails component', () => {
       });
       await user.click(operationsButton);
 
-      await waitFor(() =>
-        expect(screen.getByRole('menuitem', { name: operation })).toBeDisabled()
-      );
+      // findByRole reliably waits for the headless-ui v2 menu portal to mount.
+      const menuItem = await screen.findByRole('menuitem', { name: operation });
+      expect(menuItem).toBeDisabled();
     });
 
     it.each`
@@ -685,7 +691,8 @@ describe('HostDetails component', () => {
 
         await user.click(operationsButton);
 
-        const menuButton = screen.getByRole('menuitem', {
+        // findByRole reliably waits for the headless-ui v2 menu portal to mount.
+        const menuButton = await screen.findByRole('menuitem', {
           name: operationName,
         });
 
@@ -721,7 +728,8 @@ describe('HostDetails component', () => {
       });
       await user.click(operationsButton);
 
-      const rebootMenuItem = screen.getByRole('menuitem', {
+      // findByRole reliably waits for the headless-ui v2 menu portal to mount.
+      const rebootMenuItem = await screen.findByRole('menuitem', {
         name: 'Reboot Host',
       });
 


### PR DESCRIPTION
Root cause: Two distinct flake sources in HostDetails.test.jsx.

1) Operations-menu tests (`should show <op> operation running`,
   `should show <op> operation disabled`, `should ... Saptune ...
   solution operation button based on user abilities`, `should show
   the reboot button always enabled`) called
   `screen.getByRole('menuitem', ...)` synchronously after
   `await user.click(operationsButton)`. The headless-ui v2 Menu
   uses an async portal/floating-ui anchor positioning, so the
   menu items occasionally were not yet in the DOM when the
   query ran, producing `Unable to find role="menuitem"`. The
   one variant that wrapped the lookup in `waitFor` could still
   exhaust its 1000ms default when the suite was under CPU load.

2) `last execution overview > should be displayed when lastExecution
   has data inside` generated three faker.number.int(100) values
   (passing/warning/critical) and asserted `getByText(passingCount)`.
   With three values drawn from 0..100, two often collided,
   causing `getByText` to throw because of multiple matches (~3%).

Fix: Replace the synchronous `getByRole('menuitem', ...)` (and the `waitFor(() => expect(getByRole(...)).toBeDisabled())` variant) with `await screen.findByRole('menuitem', ...)`, which is the testing- library primitive designed to wait for asynchronous DOM mounts. For the last-execution test, replace the random faker counts with three deterministic, distinct integers (11/22/33) and assert that each is rendered. No production code changes; no factory changes.

Verified: 80/80 consecutive passes locally with TZ=UTC, jest --maxWorkers=2 (two back-to-back 30/30 runs plus a 50/50 run).

Flaky tests report payload:
[
  {
    "name": "HostDetails component \u203a forbidden actions::should disable Saptune change solution operation button based on user abilities",
    "max_score": 0.05001,
    "occurrences": 5,
    "first_seen": "2026-04-06T04:47:05Z",
    "last_seen": "2026-05-03T04:46:41Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-06T04:47:05Z",
        "commit": "431dcff683cd2d9e07cce42a08f1e9bba3f3ccef",
        "run_id": "24018677760",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-14T04:46:27Z",
        "commit": "d5c0383d3dc9d8bce172fb437441306226427928",
        "run_id": "24380994607",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-18T03:55:13Z",
        "commit": "d3b89ea0fb095b38fb28affaaecd1058c5459931",
        "run_id": "24596065451",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-23T04:13:21Z",
        "commit": "54feddca92f5302bf6ad90fd3e708b6508fc6392",
        "run_id": "24815824984",
        "score": 0.02501
      },
      {
        "timestamp": "2026-05-03T04:46:41Z",
        "commit": "aed802d8ce1e30739e2fdb764731615bef86b31c",
        "run_id": "25269875694",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/HostDetailsPage/HostDetails.test.jsx",
    "slug": "host-details",
    "branch": "fix-flaky/host-details"
  },
  {
    "name": "HostDetails component \u203a forbidden actions::should enable Saptune apply solution operation button based on user abilities",
    "max_score": 0.02501,
    "occurrences": 1,
    "first_seen": "2026-05-08T04:21:10Z",
    "last_seen": "2026-05-08T04:21:10Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-05-08T04:21:10Z",
        "commit": "17d6113a9cf5bc4e6a50d78db1b2e0288d062407",
        "run_id": "25535897343",
        "score": 0.02501
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/HostDetailsPage/HostDetails.test.jsx",
    "slug": "host-details",
    "branch": "fix-flaky/host-details"
  },
  {
    "name": "HostDetails component \u203a forbidden actions::should enable Saptune change solution operation button based on user abilities",
    "max_score": 0.05001,
    "occurrences": 3,
    "first_seen": "2026-04-14T04:46:27Z",
    "last_seen": "2026-04-26T04:23:19Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-14T04:46:27Z",
        "commit": "d5c0383d3dc9d8bce172fb437441306226427928",
        "run_id": "24380994607",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-25T03:59:43Z",
        "commit": "f003f86717bdf66015b8712a9443c63b345089d1",
        "run_id": "24921768160",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-26T04:23:19Z",
        "commit": "f003f86717bdf66015b8712a9443c63b345089d1",
        "run_id": "24947852183",
        "score": 0.02501
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/HostDetailsPage/HostDetails.test.jsx",
    "slug": "host-details",
    "branch": "fix-flaky/host-details"
  },
  {
    "name": "HostDetails component \u203a last execution overview::should be displayed when lastExecution has data inside",
    "max_score": 0.5,
    "occurrences": 4,
    "first_seen": "2026-05-05T04:18:53Z",
    "last_seen": "2026-05-09T04:25:06Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-05-05T04:18:53Z",
        "commit": "647fea1a7ce07030327a11a64c7e83eebafbd620",
        "run_id": "25357040669",
        "score": 0.09275
      },
      {
        "timestamp": "2026-05-07T04:42:28Z",
        "commit": "279c34655d05ec9b9b78dceb094adbb951d5583a",
        "run_id": "25475976804",
        "score": 0.5
      },
      {
        "timestamp": "2026-05-08T04:21:10Z",
        "commit": "17d6113a9cf5bc4e6a50d78db1b2e0288d062407",
        "run_id": "25535897343",
        "score": 0.02501
      },
      {
        "timestamp": "2026-05-09T04:25:06Z",
        "commit": "ed080da4b45c0a477a9cb84d82aa87a7a9cf7a97",
        "run_id": "25591224392",
        "score": 0.04526
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/HostDetailsPage/HostDetails.test.jsx",
    "slug": "host-details",
    "branch": "fix-flaky/host-details"
  },
  {
    "name": "HostDetails component \u203a operations::should show Change Saptune Solution operation disabled",
    "max_score": 0.05001,
    "occurrences": 5,
    "first_seen": "2026-03-31T04:36:56Z",
    "last_seen": "2026-05-03T04:46:41Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-03-31T04:36:56Z",
        "commit": "0976bc51a7a041d5cc409131c821e8cdf001f9d3",
        "run_id": "23780262451",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-15T04:06:46Z",
        "commit": "8360d6b6b5a0426e4e554ed7f3490430c5b87d10",
        "run_id": "24435409340",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-20T04:16:58Z",
        "commit": "d3b89ea0fb095b38fb28affaaecd1058c5459931",
        "run_id": "24647765014",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-24T04:16:50Z",
        "commit": "4d018d598251ab302f8515535a0582af06fcc0e4",
        "run_id": "24871468908",
        "score": 0.02501
      },
      {
        "timestamp": "2026-05-03T04:46:41Z",
        "commit": "aed802d8ce1e30739e2fdb764731615bef86b31c",
        "run_id": "25269875694",
        "score": 0.02501
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/HostDetailsPage/HostDetails.test.jsx",
    "slug": "host-details",
    "branch": "fix-flaky/host-details"
  },
  {
    "name": "HostDetails component \u203a operations::should show Host reboot operation running",
    "max_score": 0.5,
    "occurrences": 4,
    "first_seen": "2026-03-29T04:39:15Z",
    "last_seen": "2026-05-07T04:42:28Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-03-29T04:39:15Z",
        "commit": "8acbe1d89dbabcacb496b0b3646ec73aff06bb5b",
        "run_id": "23701274126",
        "score": 0.5
      },
      {
        "timestamp": "2026-04-25T03:59:43Z",
        "commit": "f003f86717bdf66015b8712a9443c63b345089d1",
        "run_id": "24921768160",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-28T04:40:35Z",
        "commit": "c75a8203543a097f7bd551d93a6b165626b58df8",
        "run_id": "25033785516",
        "score": 0.02501
      },
      {
        "timestamp": "2026-05-07T04:42:28Z",
        "commit": "279c34655d05ec9b9b78dceb094adbb951d5583a",
        "run_id": "25475976804",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/HostDetailsPage/HostDetails.test.jsx",
    "slug": "host-details",
    "branch": "fix-flaky/host-details"
  },
  {
    "name": "HostDetails component \u203a operations::should show Saptune apply operation running",
    "max_score": 0.25,
    "occurrences": 8,
    "first_seen": "2026-03-29T04:39:15Z",
    "last_seen": "2026-05-05T04:18:53Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-03-29T04:39:15Z",
        "commit": "8acbe1d89dbabcacb496b0b3646ec73aff06bb5b",
        "run_id": "23701274126",
        "score": 0.05001
      },
      {
        "timestamp": "2026-03-30T04:46:11Z",
        "commit": "8acbe1d89dbabcacb496b0b3646ec73aff06bb5b",
        "run_id": "23727952270",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-08T04:36:50Z",
        "commit": "c1c8179aea75eb25e7a1b991435fe595884aa945",
        "run_id": "24117491595",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-14T04:46:27Z",
        "commit": "d5c0383d3dc9d8bce172fb437441306226427928",
        "run_id": "24380994607",
        "score": 0.25
      },
      {
        "timestamp": "2026-04-27T04:27:10Z",
        "commit": "f003f86717bdf66015b8712a9443c63b345089d1",
        "run_id": "24976109847",
        "score": 0.1977
      },
      {
        "timestamp": "2026-04-30T04:39:43Z",
        "commit": "1d3d19c733a35d8280a3d9b7b1bd78851868790b",
        "run_id": "25147218254",
        "score": 0.05001
      },
      {
        "timestamp": "2026-05-03T04:46:41Z",
        "commit": "aed802d8ce1e30739e2fdb764731615bef86b31c",
        "run_id": "25269875694",
        "score": 0.05001
      },
      {
        "timestamp": "2026-05-05T04:18:53Z",
        "commit": "647fea1a7ce07030327a11a64c7e83eebafbd620",
        "run_id": "25357040669",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/HostDetailsPage/HostDetails.test.jsx",
    "slug": "host-details",
    "branch": "fix-flaky/host-details"
  },
  {
    "name": "HostDetails component \u203a operations::should show Saptune change operation running",
    "max_score": 0.05001,
    "occurrences": 6,
    "first_seen": "2026-03-31T04:36:56Z",
    "last_seen": "2026-05-10T04:53:02Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-03-31T04:36:56Z",
        "commit": "0976bc51a7a041d5cc409131c821e8cdf001f9d3",
        "run_id": "23780262451",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-01T04:50:23Z",
        "commit": "ccc91639f04ea26ed14e5c7eeb59807d9f1f1d3b",
        "run_id": "23832077383",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-08T04:36:50Z",
        "commit": "c1c8179aea75eb25e7a1b991435fe595884aa945",
        "run_id": "24117491595",
        "score": 0.02501
      },
      {
        "timestamp": "2026-04-10T04:47:52Z",
        "commit": "54bd084c152259334fd242f53ab63870b360ad6d",
        "run_id": "24226469869",
        "score": 0.02501
      },
      {
        "timestamp": "2026-05-03T04:46:41Z",
        "commit": "aed802d8ce1e30739e2fdb764731615bef86b31c",
        "run_id": "25269875694",
        "score": 0.05001
      },
      {
        "timestamp": "2026-05-10T04:53:02Z",
        "commit": "ed080da4b45c0a477a9cb84d82aa87a7a9cf7a97",
        "run_id": "25619877756",
        "score": 0.05001
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/HostDetailsPage/HostDetails.test.jsx",
    "slug": "host-details",
    "branch": "fix-flaky/host-details"
  }
]

# Description

Please include a summary of the changes and the related issue, if it exists. 
Also, include relevant motivation and context for this PR. List any dependencies that are required for this change.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [ ] **DONE**
