### PR TITLE
fix(test): resolve flaky HostsList "should put the filters values in …

### DIFF
--- a/assets/js/pages/HostsList/HostsList.test.jsx
+++ b/assets/js/pages/HostsList/HostsList.test.jsx
@@ -453,6 +453,7 @@ describe('HostsLists component', () => {
 
       const hosts = hostFactory.buildList(1, {
         id: 'host1',
+        hostname: 'host-1',
         tags: [{ value: 'Tag1' }],
       });
       const sid = generateSid();


### PR DESCRIPTION
…the query string when filters are selected"

Root cause: hostFactory.hostname uses `${faker.person.firstName()}_${sequence}`, which can produce names containing apostrophes (D'Angelo, O'Brien) or accented characters. Such characters get URL-encoded in window.location.search but the test asserts equality against the raw, unencoded hostname, causing intermittent failures.

Fix: override `hostname: 'host-1'` (URL-safe) when building the test host so the assertion compares deterministic, encoding-equivalent strings. Test-only change; no production code or shared factory touched. Verified 30/30 passes on the targeted test plus full file (16/16) green.

Flaky tests report payload:
[
  {
    "name": "HostsLists component \u203a filtering::should put the filters values in the query string when filters are selected",
    "max_score": 0.02501,
    "occurrences": 2,
    "first_seen": "2026-05-01T04:54:29Z",
    "last_seen": "2026-05-02T04:18:22Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-05-01T04:54:29Z",
        "commit": "aed802d8ce1e30739e2fdb764731615bef86b31c",
        "run_id": "25202443824",
        "score": 0.02501
      },
      {
        "timestamp": "2026-05-02T04:18:22Z",
        "commit": "aed802d8ce1e30739e2fdb764731615bef86b31c",
        "run_id": "25243272334",
        "score": 0.02501
      }
    ],
    "status": "pending",
    "test_file": "assets/js/pages/HostsList/HostsList.test.jsx",
    "slug": "hosts-list",
    "branch": "fix-flaky/hosts-list"
  }
]

# Description

Please include a summary of the changes and the related issue, if it exists. 
Also, include relevant motivation and context for this PR. List any dependencies that are required for this change.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [ ] **DONE**
