### PR TITLE
fix(test): resolve flaky Label "should display an info tooltip if spe…

### DIFF
--- a/assets/js/common/Label/Label.test.jsx
+++ b/assets/js/common/Label/Label.test.jsx
@@ -19,15 +19,15 @@ describe('Label Component', () => {
 
   it('should display an info tooltip if specified', async () => {
     const user = userEvent.setup();
-    const labelContent = faker.word.noun();
-    const labelInfoContent = faker.word.noun();
+    const labelContent = `label-${faker.string.uuid()}`;
+    const labelInfoContent = `info-${faker.string.uuid()}`;
 
     render(<Label info={labelInfoContent}>{labelContent}</Label>);
 
     const icon = screen.getByTestId('eos-svg-component');
     await act(async () => user.hover(icon));
 
-    expect(screen.getByText(labelInfoContent)).toBeVisible();
+    expect(await screen.findByText(labelInfoContent)).toBeVisible();
   });
 
   it('should display an asterisk for required fields', () => {


### PR DESCRIPTION
…cified"

Root cause: two issues compounded.
  1. labelContent and labelInfoContent were both generated via faker.word.noun(), which can return the same word (~0.1% probability). When that happened, screen.getByText(labelInfoContent) matched both the label text and the tooltip overlay text and threw "Found multiple elements with the text".
  2. The tooltip is rendered through rc-tooltip with a fade motion (motionName: 'rc-tooltip-fade'), so its overlay mounts asynchronously after hover. Asserting with the synchronous getByText right after the hover could miss the overlay node before it is attached.

Fix: prefix labelContent and labelInfoContent with stable, distinct namespaces plus faker.string.uuid() to guarantee uniqueness across the rendered DOM, and await screen.findByText to give rc-tooltip's motion-driven mount time to complete before asserting visibility. Test-file change only.

Flaky tests report payload:
[
  {
    "name": "Label Component::should display an info tooltip if specified",
    "max_score": 0.05001,
    "occurrences": 2,
    "first_seen": "2026-04-09T04:32:26Z",
    "last_seen": "2026-04-12T04:49:17Z",
    "suite": "Jest \u2014 Node 22.15.1",
    "reports": [
      {
        "timestamp": "2026-04-09T04:32:26Z",
        "commit": "54bd084c152259334fd242f53ab63870b360ad6d",
        "run_id": "24172058823",
        "score": 0.05001
      },
      {
        "timestamp": "2026-04-12T04:49:17Z",
        "commit": "8b846349ed7ab730785cb8395f839a927bde9b76",
        "run_id": "24298708972",
        "score": 0.02501
      }
    ],
    "status": "pending",
    "test_file": "assets/js/common/Label/Label.test.jsx",
    "slug": "label",
    "branch": "fix-flaky/label"
  }
]

# Description

Please include a summary of the changes and the related issue, if it exists. 
Also, include relevant motivation and context for this PR. List any dependencies that are required for this change.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [ ] **DONE**
