### PR TITLE
Make prepare-release workflow idempotent + auto-heal

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -64,16 +64,24 @@ jobs:
             echo "next=${next}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Ensure no release is already in flight
+      - name: Ensure no different release is already in flight
+        env:
+          NEXT: ${{ steps.versions.outputs.next }}
         run: |
           set -euo pipefail
           open=$(gh pr list \
             --base release --state open \
             --json number,title,headRefName)
-          count=$(echo "$open" | jq 'length')
+          others=$(echo "$open" | jq --arg ver "${NEXT}" '
+            [.[] | select(
+              ((.headRefName | startswith("port/\($ver)/")) | not)
+              and (.headRefName != "version/\($ver)")
+            )]
+          ')
+          count=$(echo "$others" | jq 'length')
           if [ "$count" -gt 0 ]; then
-            echo "::error::Found ${count} open PR(s) against 'release'. Close or merge them before starting a new release."
-            echo "$open" | jq -r '.[] | "  #\(.number) \(.title) (head: \(.headRefName))"'
+            echo "::error::Found ${count} open PR(s) against 'release' for a different release. Close or merge them before starting a new ${NEXT} release."
+            echo "$others" | jq -r '.[] | "  #\(.number) \(.title) (head: \(.headRefName))"'
             exit 1
           fi
 
@@ -108,6 +116,31 @@ jobs:
 
             echo "::group::Porting PR #${num} (${sha}) onto ${branch}"
 
+            existing=$(gh pr list --head "$branch" --base release --state all \
+              --json number,state --limit 1)
+            case "$(echo "$existing" | jq -r '.[0].state // "NONE"')" in
+              OPEN)
+                echo "Porting PR #$(echo "$existing" | jq -r '.[0].number') already open for ${branch} — skipping."
+                echo "::endgroup::"
+                continue
+                ;;
+              MERGED)
+                echo "Porting PR #$(echo "$existing" | jq -r '.[0].number') already merged into 'release' — skipping."
+                echo "::endgroup::"
+                continue
+                ;;
+              CLOSED)
+                echo "::warning::Porting PR #$(echo "$existing" | jq -r '.[0].number') for ${branch} was closed by a reviewer — skipping. Delete it manually if you want to recreate."
+                echo "::endgroup::"
+                continue
+                ;;
+            esac
+
+            if git ls-remote --exit-code --heads origin "$branch" > /dev/null 2>&1; then
+              echo "Found orphan branch ${branch} (no PR) — deleting before recreate."
+              git push origin --delete "$branch"
+            fi
+
             git checkout release
             git checkout -b "$branch"
 
@@ -119,7 +152,7 @@ jobs:
                 git cherry-pick -x -m 1 "$sha"
               else
                 cat cp.err
-                echo "::error::cherry-pick of ${sha} (PR #${num}) failed. Resolve the conflict manually, close any partially-opened porting PRs, delete their branches, then re-run this workflow."
+                echo "::error::cherry-pick of ${sha} (PR #${num}) failed due to conflicts. Resolve manually (check out '${branch}', complete the port, push, open a PR against 'release'), then re-run this workflow to continue with the remaining ports."
                 exit 1
               fi
             fi
@@ -141,6 +174,28 @@ jobs:
         run: |
           set -euo pipefail
           branch="version/${NEXT}"
+
+          existing=$(gh pr list --head "$branch" --base release --state all \
+            --json number,state --limit 1)
+          case "$(echo "$existing" | jq -r '.[0].state // "NONE"')" in
+            OPEN)
+              echo "Version-trigger PR #$(echo "$existing" | jq -r '.[0].number') already open — nothing to do."
+              exit 0
+              ;;
+            MERGED)
+              echo "::error::Version-trigger PR #$(echo "$existing" | jq -r '.[0].number') has already been merged — release ${NEXT} was already triggered. Bump again to start a new release."
+              exit 1
+              ;;
+            CLOSED)
+              echo "::error::Version-trigger PR #$(echo "$existing" | jq -r '.[0].number') was closed. Delete it (and branch '${branch}') manually if you want to retry the release."
+              exit 1
+              ;;
+          esac
+
+          if git ls-remote --exit-code --heads origin "$branch" > /dev/null 2>&1; then
+            echo "Found orphan branch ${branch} (no PR) — deleting before recreate."
+            git push origin --delete "$branch"
+          fi
 
           git checkout release
           git checkout -b "$branch"

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -116,29 +116,38 @@ jobs:
 
             echo "::group::Porting PR #${num} (${sha}) onto ${branch}"
 
-            existing=$(gh pr list --head "$branch" --base release --state all \
-              --json number,state --limit 1)
-            case "$(echo "$existing" | jq -r '.[0].state // "NONE"')" in
-              OPEN)
-                echo "Porting PR #$(echo "$existing" | jq -r '.[0].number') already open for ${branch} — skipping."
-                echo "::endgroup::"
-                continue
-                ;;
-              MERGED)
-                echo "Porting PR #$(echo "$existing" | jq -r '.[0].number') already merged into 'release' — skipping."
-                echo "::endgroup::"
-                continue
-                ;;
-              CLOSED)
-                echo "::warning::Porting PR #$(echo "$existing" | jq -r '.[0].number') for ${branch} was closed by a reviewer — skipping. Delete it manually if you want to recreate."
-                echo "::endgroup::"
-                continue
-                ;;
-            esac
-
             if git ls-remote --exit-code --heads origin "$branch" > /dev/null 2>&1; then
-              echo "Found orphan branch ${branch} (no PR) — deleting before recreate."
-              git push origin --delete "$branch"
+              existing=$(gh pr list --head "$branch" --base release --state all \
+                --json number,state --limit 1)
+              case "$(echo "$existing" | jq -r '.[0].state // "NONE"')" in
+                OPEN)
+                  echo "Porting PR #$(echo "$existing" | jq -r '.[0].number') already open for ${branch} — skipping."
+                  echo "::endgroup::"
+                  continue
+                  ;;
+                MERGED)
+                  echo "Porting PR #$(echo "$existing" | jq -r '.[0].number') already merged into 'release' — skipping."
+                  echo "::endgroup::"
+                  continue
+                  ;;
+                CLOSED)
+                  echo "::warning::Porting PR #$(echo "$existing" | jq -r '.[0].number') was closed but branch ${branch} still exists — skipping. Delete the branch manually to recreate the PR."
+                  echo "::endgroup::"
+                  continue
+                  ;;
+                NONE)
+                  echo "Found orphan branch ${branch} (no PR) — deleting before recreate."
+                  git push origin --delete "$branch"
+                  ;;
+              esac
+            else
+              merged=$(gh pr list --head "$branch" --base release --state merged \
+                --json number --limit 1)
+              if [ "$(echo "$merged" | jq 'length')" -gt 0 ]; then
+                echo "Porting PR #$(echo "$merged" | jq -r '.[0].number') already merged into 'release' (branch deleted) — skipping."
+                echo "::endgroup::"
+                continue
+              fi
             fi
 
             git checkout release
@@ -175,26 +184,30 @@ jobs:
           set -euo pipefail
           branch="version/${NEXT}"
 
-          existing=$(gh pr list --head "$branch" --base release --state all \
-            --json number,state --limit 1)
-          case "$(echo "$existing" | jq -r '.[0].state // "NONE"')" in
-            OPEN)
-              echo "Version-trigger PR #$(echo "$existing" | jq -r '.[0].number') already open — nothing to do."
-              exit 0
-              ;;
-            MERGED)
-              echo "::error::Version-trigger PR #$(echo "$existing" | jq -r '.[0].number') has already been merged — release ${NEXT} was already triggered. Bump again to start a new release."
-              exit 1
-              ;;
-            CLOSED)
-              echo "::error::Version-trigger PR #$(echo "$existing" | jq -r '.[0].number') was closed. Delete it (and branch '${branch}') manually if you want to retry the release."
-              exit 1
-              ;;
-          esac
+          merged=$(gh pr list --head "$branch" --base release --state merged \
+            --json number --limit 1)
+          if [ "$(echo "$merged" | jq 'length')" -gt 0 ]; then
+            echo "::error::Version-trigger PR #$(echo "$merged" | jq -r '.[0].number') has already been merged — release ${NEXT} was triggered. Bump to a new version to start another release."
+            exit 1
+          fi
 
           if git ls-remote --exit-code --heads origin "$branch" > /dev/null 2>&1; then
-            echo "Found orphan branch ${branch} (no PR) — deleting before recreate."
-            git push origin --delete "$branch"
+            existing=$(gh pr list --head "$branch" --base release --state all \
+              --json number,state --limit 1)
+            case "$(echo "$existing" | jq -r '.[0].state // "NONE"')" in
+              OPEN)
+                echo "Version-trigger PR #$(echo "$existing" | jq -r '.[0].number') already open — nothing to do."
+                exit 0
+                ;;
+              CLOSED)
+                echo "::error::Version-trigger PR #$(echo "$existing" | jq -r '.[0].number') was closed but branch '${branch}' still exists. Delete the branch manually if you want to retry."
+                exit 1
+                ;;
+              NONE)
+                echo "Found orphan branch ${branch} (no PR) — deleting before recreate."
+                git push origin --delete "$branch"
+                ;;
+            esac
           fi
 
           git checkout release

--- a/docs/superpowers/specs/2026-06-09-prepare-release-idempotency-design.md
+++ b/docs/superpowers/specs/2026-06-09-prepare-release-idempotency-design.md
@@ -24,17 +24,30 @@ A re-run of `prepare-release` for the **same** `NEXT` version transparently pick
 
 ### Per-item state model
 
-For each piece of work (each porting PR, the version-trigger PR), look up the existing PR by head branch and act on its state:
+For each piece of work, **branch existence is the primary signal of "live work"**. The PR state only matters when the branch is present. A closed-then-cleaned-up PR (branch gone) is treated as "no work yet" so the same version can be re-attempted from scratch.
 
-| Item state | Action |
-|---|---|
-| PR OPEN | Skip — already done |
-| PR MERGED (porting) | Skip — already on `release` |
-| PR MERGED (version-trigger) | **Abort** — release already triggered |
-| PR CLOSED (porting) | Skip with warning — respect reviewer's rejection |
-| PR CLOSED (version-trigger) | **Abort** — tell user to delete manually if they want to retry |
-| No PR, orphan branch exists | Delete orphan, recreate fresh |
-| Nothing | Fresh creation (current behavior) |
+**Porting PR per item:**
+
+| Branch | Latest PR | Action |
+|---|---|---|
+| exists | OPEN | Skip — already done |
+| exists | MERGED | Skip — already on `release` |
+| exists | CLOSED | Skip with warning — respect reviewer's close; user can delete the branch to recreate |
+| exists | none | Delete orphan branch, recreate fresh |
+| missing | MERGED | Skip — already on `release` (branch was auto-deleted on merge) |
+| missing | any other | Fresh creation |
+
+**Version-trigger PR:**
+
+| Branch | Latest PR | Action |
+|---|---|---|
+| (any) | MERGED ever exists | **Abort** — release already triggered |
+| exists | OPEN | Skip (exit 0) — already done |
+| exists | CLOSED | **Abort** — tell user to delete branch manually to retry |
+| exists | none | Delete orphan, recreate fresh |
+| missing | none / CLOSED-only | Fresh creation |
+
+(MERGED is checked first via a dedicated `--state merged` query, so it short-circuits regardless of branch state — preventing accidental re-trigger of a release that's already shipped.)
 
 ### "In-flight" guard refinement
 

--- a/docs/superpowers/specs/2026-06-09-prepare-release-idempotency-design.md
+++ b/docs/superpowers/specs/2026-06-09-prepare-release-idempotency-design.md
@@ -1,0 +1,67 @@
+# Prepare-release workflow: idempotent + auto-heal design
+
+**Status:** Approved
+**Date:** 2026-06-09
+**Affects:** `.github/workflows/prepare-release.yaml`
+
+## Problem
+
+`prepare-release.yaml` is not safe to re-run after partial failure. Each step (porting PRs, version-trigger PR) does `git push` then `gh pr create`; if PR creation fails (e.g., missing label), the branch is left on the remote without a PR. Re-running then collides with the orphan branch (non-fast-forward push) or trips the "no release in flight" guard against its own prior-run leftovers.
+
+Observed example (run 27210429356): `gh pr create --label skip-release-notes` failed mid-step, leaving `version/9.9.1` orphaned; subsequent re-runs failed at the push.
+
+## Goal
+
+A re-run of `prepare-release` for the **same** `NEXT` version transparently picks up where a prior run left off. A run for a **different** in-flight version still fails loudly.
+
+## Non-goals
+
+- Restarting a release that was already triggered (merged version-trigger PR).
+- Auto-recreating PRs that a reviewer explicitly closed.
+- Making the workflow safe under concurrent runs (still gated by `concurrency: prepare-release`).
+
+## Design
+
+### Per-item state model
+
+For each piece of work (each porting PR, the version-trigger PR), look up the existing PR by head branch and act on its state:
+
+| Item state | Action |
+|---|---|
+| PR OPEN | Skip — already done |
+| PR MERGED (porting) | Skip — already on `release` |
+| PR MERGED (version-trigger) | **Abort** — release already triggered |
+| PR CLOSED (porting) | Skip with warning — respect reviewer's rejection |
+| PR CLOSED (version-trigger) | **Abort** — tell user to delete manually if they want to retry |
+| No PR, orphan branch exists | Delete orphan, recreate fresh |
+| Nothing | Fresh creation (current behavior) |
+
+### "In-flight" guard refinement
+
+The existing "no release in flight" check fails on **any** open PR against `release`. Refine it to fail only on PRs whose head doesn't match `port/${NEXT}/*` or `version/${NEXT}` — so leftovers from a prior run of the **same** version don't block resume, but an in-flight **different** version does.
+
+### Cherry-pick conflict handling
+
+Cherry-pick conflicts still abort the workflow. The error message is updated to reflect auto-resume: the user resolves the one conflict (checks out the branch, completes the port, pushes, opens a PR), then re-runs to continue with the remaining ports. Already-created porting PRs are skipped on the resumed run.
+
+## Implementation
+
+Three localized edits to `prepare-release.yaml`:
+
+1. **Hoist `NEXT` to a step-level `env:`** on both the "in-flight" check and the porting loop, so the `jq --arg ver` pattern-match works without YAML interpolation gymnastics.
+2. **"Ensure no release is in flight"**: filter the `gh pr list` output through `jq` to exclude PRs matching `port/${NEXT}/*` or `version/${NEXT}` before counting.
+3. **Porting loop body**: probe `gh pr list --head $branch --state all` at the top of each iteration; switch on state with `case`; if no PR but orphan branch exists, `git push origin --delete` before the cherry-pick.
+4. **Version-trigger step**: same probe pattern; OPEN → exit 0; CLOSED/MERGED → exit 1 with explicit user instruction; otherwise delete orphan and proceed.
+
+The `case` statement is the same shape in both places; differs only in the CLOSED/MERGED branches.
+
+## Tests
+
+All run on `balanza/trento_web` (origin), dispatched with `--ref` pointing at the feature branch:
+
+1. **Clean run from empty state** — close all release PRs + delete branches; dispatch; expect 2 fresh PRs (1 porting, 1 version-trigger).
+2. **Resume after version-trigger failure** — from a successful state, close+delete the version-trigger PR/branch only; re-dispatch; expect porting step skips with "already open", version-trigger step recreates fresh.
+3. **Closed version-trigger PR** — from successful state, close (don't delete branch) the version-trigger PR; re-dispatch; expect workflow fails at version-trigger step with "delete it manually" message.
+4. **Orphan port branch reaped** — from empty state, manually push `port/9.9.1/pr-23` with no PR; dispatch; expect orphan deleted then recreated via cherry-pick.
+
+Pass criteria: each test's expected log line appears in the run's step output, and final repo state matches the expectation.


### PR DESCRIPTION
## Summary

Re-running `prepare-release.yaml` for the same `NEXT` version now picks up where a prior run left off instead of colliding with leftover branches or its own in-flight guard. A run for a different in-flight version still fails loudly.

Motivated by a partial-failure scenario: the version-trigger step does `git push` then `gh pr create`; when PR creation failed mid-step (missing `skip-release-notes` label), the orphan branch made every subsequent re-run fail with a non-fast-forward push.

## Behavior changes

- **"Ensure no release in flight"** now filters by `NEXT` version pattern. Open PRs whose head matches `port/${NEXT}/*` or `version/${NEXT}` are treated as resumable; other open PRs against `release` still block.
- **Porting loop** probes each branch first. With the branch present, latest PR state decides: `OPEN`/`MERGED` → skip, `CLOSED` → warn-and-skip (respect reviewer; user deletes branch to recreate), `NONE` → orphan, delete and recreate. With the branch missing, only a `MERGED` PR counts as "done" — otherwise create fresh.
- **Version-trigger step** uses the same probe but is stricter: `MERGED` always aborts (release already triggered), `CLOSED` with branch present aborts (user must delete branch to retry).
- **Cherry-pick error message** updated to reflect auto-resume (only the conflicting port needs manual resolution; already-created ports auto-skip on the retry).

Design philosophy: **branch existence is the primary signal of live work**. A closed-then-cleaned-up PR (branch gone) is treated as "no work yet" so the same version can be re-attempted from scratch.

Spec: `docs/superpowers/specs/2026-06-09-prepare-release-idempotency-design.md`

## Test plan

Ran 4 scenarios against this repo on dispatched workflow_dispatch runs from this branch — all green:

- [x] **Clean run from empty state** — 2 fresh PRs created (run 27214177710)
- [x] **Resume after version-trigger failure** — porting PR skipped with "already open #29", version-trigger recreated fresh (run 27214321896)
- [x] **Closed version-trigger PR, branch still present** — workflow aborts at version-trigger with "Delete the branch manually if you want to retry" (run 27214457081)
- [x] **True orphan branch reaped** — manually pushed stub `port/9.9.1/pr-22` with no PR ever; workflow detected "Found orphan branch ... — deleting before recreate" and deleted it before attempting cherry-pick (run 27214747696)

🤖 Generated with [Claude Code](https://claude.com/claude-code)